### PR TITLE
Add option to disable adding labels to card

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ jobs:
                   trello-conflicting-labels: 'feature;bug;chore' # When a card has one of these labels then branch category label is not assigned
                   trello-card-in-branch-name: false # When true search for card name (e.g. "1234-card-title") in the branch name if card URL is not found in PR description or comments. If card id is found from branch then adds a comment with the card URL.
                   trello-card-position: "top" # Position of the card after being moved to a list (can be "top" or "bottom", default to "top")
+                  trello-add-labels-to-cards: true # Enable or disable the automatic addition of labels to cards (default to "true")
 ```
 
 [Here is how you can find out your board and list IDs](https://stackoverflow.com/a/50908600/2311110).

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
         default: false
     trello-card-position:
         description: Position of the card after being moved to a list (can be "top" or "bottom")
+    trello-add-labels-to-cards:
+        description: Enable or disable the automatic addition of labels to cards
+        default: true
 
 runs:
     using: node20

--- a/dist/index.js
+++ b/dist/index.js
@@ -36867,6 +36867,7 @@ const trelloListIdPrClosed = core.getInput('trello-list-id-pr-closed')
 const trelloConflictingLabels = core.getInput('trello-conflicting-labels')?.split(';')
 const trelloCardInBranchName = core.getBooleanInput('trello-card-in-branch-name')
 const trelloCardPosition = core.getInput('trello-card-position')
+const trelloAddLabelsToCards = core.getBooleanInput('trello-add-labels-to-cards')
 
 const octokit = github.getOctokit(githubToken)
 const repoOwner = (payload.organization || payload.repository.owner).login
@@ -36907,7 +36908,9 @@ async function run(pr) {
 		}
 		await addAttachmentToCards(cardIds, url)
 		await updateCardMembers(cardIds, assignees)
-		await addLabelToCards(cardIds, pr.head)
+		if (trelloAddLabelsToCards) {
+			await addLabelToCards(cardIds, pr.head)
+		}
 		await commentCardLink(cardIds, pr.body, comments)
 	} catch (error) {
 		core.setFailed(error)

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const trelloListIdPrClosed = core.getInput('trello-list-id-pr-closed')
 const trelloConflictingLabels = core.getInput('trello-conflicting-labels')?.split(';')
 const trelloCardInBranchName = core.getBooleanInput('trello-card-in-branch-name')
 const trelloCardPosition = core.getInput('trello-card-position')
+const trelloAddLabelsToCards = core.getBooleanInput('trello-add-labels-to-cards')
 
 const octokit = github.getOctokit(githubToken)
 const repoOwner = (payload.organization || payload.repository.owner).login
@@ -58,7 +59,9 @@ async function run(pr) {
 		}
 		await addAttachmentToCards(cardIds, url)
 		await updateCardMembers(cardIds, assignees)
-		await addLabelToCards(cardIds, pr.head)
+		if (trelloAddLabelsToCards) {
+			await addLabelToCards(cardIds, pr.head)
+		}
 		await commentCardLink(cardIds, pr.body, comments)
 	} catch (error) {
 		core.setFailed(error)


### PR DESCRIPTION
##### Checklist

-   [x] Used prettier
-   [x] Ran `yarn build`

----

Hi !
This PR add the possibility to disable the labeling of cards entirely.
We encountered some problems with labels behind added to card we didn't want and maintaining the list of conflicting labels is too tedious.

The default is `true` (current behavior).

(I'll rebase and rebuild if any other PR are merged)
