### PR TITLE
Add mapping between Github and Trello username + Add option to disable removal of unrelated members

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ jobs:
                   trello-card-in-branch-name: false # When true search for card name (e.g. "1234-card-title") in the branch name if card URL is not found in PR description or comments. If card id is found from branch then adds a comment with the card URL.
                   trello-card-position: "top" # Position of the card after being moved to a list (can be "top" or "bottom", default to "top")
                   trello-add-labels-to-cards: true # Enable or disable the automatic addition of labels to cards (default to "true")
+                  trello-remove-unrelated-members: true # Enable or disable the removal of unrelated users on trello cards (default to "true")
+                  # Newline-separated list of mapping between Github username and Trello username. 
+                  # If the current username is not in the list, we still try to find a Trello user with that username
+                  # Example:
+                  map-github-users-to-trello: |-
+                    GithubUser1:TrelloUser1
+                    GithubUser2:TrelloUser2
 ```
 
 [Here is how you can find out your board and list IDs](https://stackoverflow.com/a/50908600/2311110).

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,15 @@ inputs:
     trello-add-labels-to-cards:
         description: Enable or disable the automatic addition of labels to cards
         default: true
-
+    trello-remove-unrelated-members:
+        description: Enable or disable the removal of unrelated users on trello cards
+        default: true
+    map-github-users-to-trello:
+        description: |-
+          Newline-separated list of mapping between Github username and Trello username. Example:
+          map-github-users-to-trello: |-
+            GithubUser1:TrelloUser1
+            GithubUser2:TrelloUser2
 runs:
     using: node20
     main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ const trelloConflictingLabels = core.getInput('trello-conflicting-labels')?.spli
 const trelloCardInBranchName = core.getBooleanInput('trello-card-in-branch-name')
 const trelloCardPosition = core.getInput('trello-card-position')
 const trelloAddLabelsToCards = core.getBooleanInput('trello-add-labels-to-cards')
+const trelloRemoveUnrelatedMembers = core.getBooleanInput('trello-remove-unrelated-members')
+const mapGithubUsersToTrello = core.getInput('map-github-users-to-trello')
 
 const octokit = github.getOctokit(githubToken)
 const repoOwner = (payload.organization || payload.repository.owner).login
@@ -281,13 +283,18 @@ async function updateCardMembers(cardIds, assignees) {
 	cardIds.forEach(async (cardId) => {
 		const cardInfo = await getCardInfo(cardId)
 
-		removeUnrelatedMembers(cardInfo, memberIds)
+		if (trelloRemoveUnrelatedMembers) {
+			removeUnrelatedMembers(cardInfo, memberIds)
+		}
 		addNewMembers(cardInfo, memberIds)
 	})
 }
 
 function getTrelloMemberId(githubUserName) {
-	const username = githubUserName.replace('-', '_')
+	let username = githubUserName.replace('-', '_')
+	if (mapGithubUsersToTrello.trim() !== '') {
+		username = getTrelloUsernameFromInputMap(githubUserName) || username
+	}
 
 	console.log('Searching Trello member id by username', username)
 
@@ -318,6 +325,22 @@ function getTrelloMemberId(githubUserName) {
 		.catch((error) => {
 			console.error(`Error ${error.response.status} ${error.response.statusText}`, url)
 		})
+}
+
+function getTrelloUsernameFromInputMap(githubUserName) {
+	for (const line of mapGithubUsersToTrello.split(/[\r\n]/)) {
+		const parts = line.trim().split(':')
+		if (parts.length < 2) {
+			console.error(
+				'Error : Mapping of Github user to Trello does not contains 2 username separated by ":"',
+				line,
+			)
+			continue
+		}
+		if (parts[0].trim() === githubUserName && parts[1].trim() !== '') {
+			return parts[1].trim()
+		}
+	}
 }
 
 function removeUnrelatedMembers(cardInfo, memberIds) {


### PR DESCRIPTION
##### Checklist

-   [x] Used prettier
-   [x] Ran `yarn build`

---

Hi !
This PR add the possibility specify a mapping between Github and Trello users, as these not always exactly the same.
It also add the possibility to disable the removal of unrelated members. The default is true (current behavior).

(I'll rebase and rebuild if any other PR are merged)