### PR TITLE
fix: make card action optional

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34467,7 +34467,7 @@ async function getMultipleCardIdsFromBranchName(conf, branchName) {
 async function isCardAlreadyLinked(cardIds, shortId) {
     return cardIds.some(async (cardId) => {
         const card = await (0, trello_1.getCardInfo)(cardId);
-        return card.actions.some((action) => action.data.card.idShort === parseInt(shortId));
+        return card.actions?.some((action) => action.data.card.idShort === parseInt(shortId)) ?? false;
     });
 }
 /**
@@ -34492,7 +34492,7 @@ async function getTrelloCardByTitle(title, shortId) {
         .sort((a, b) => new Date(b.dateLastActivity).getTime() - new Date(a.dateLastActivity).getTime())
         .map((card) => (0, trello_1.getCardInfo)(card.id)));
     return cards.find((card) => card.idShort === parseInt(shortId) ||
-        card.actions.some((action) => action.data.card.idShort === parseInt(shortId)))?.shortLink;
+        (card.actions?.some((action) => action.data.card.idShort === parseInt(shortId)) ?? false))?.shortLink;
 }
 /**
  * Creates a new card when user has written "/new-trello-card" to the PR description

--- a/src/actions/getCardIds.ts
+++ b/src/actions/getCardIds.ts
@@ -137,11 +137,11 @@ async function getMultipleCardIdsFromBranchName(conf: Conf, branchName: string) 
 	}
 }
 
-async function isCardAlreadyLinked(cardIds: string[], shortId: string) {
+async function isCardAlreadyLinked(cardIds: string[], shortId: string): Promise<boolean> {
 	return cardIds.some(async (cardId) => {
 		const card = await getCardInfo(cardId)
 
-		return card.actions.some((action) => action.data.card.idShort === parseInt(shortId))
+		return card.actions?.some((action) => action.data.card.idShort === parseInt(shortId)) ?? false
 	})
 }
 
@@ -174,7 +174,7 @@ async function getTrelloCardByTitle(title: string, shortId: string) {
 	return cards.find(
 		(card) =>
 			card.idShort === parseInt(shortId) ||
-			card.actions.some((action) => action.data.card.idShort === parseInt(shortId)),
+			(card.actions?.some((action) => action.data.card.idShort === parseInt(shortId)) ?? false),
 	)?.shortLink
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export type Card = {
 	url: string
 	shortUrl: string
 	shortLink: string
-	actions: {
+	actions?: {
 		data: {
 			card: {
 				idShort: number


### PR DESCRIPTION
##### Checklist

-   [ ] Ran `npm run build` with Node v20
-   [ ] Updated README.md and action.yml if needed

### Context
- action version: 9.6.2 (updated recently because we need the fix implemented in this version for multiple boards orgs)
- 1 workspace with 3 boards 

### Issue found

```
--- FIND CARDS ---
Searching cards from branch name feat/34-xxxxxxxx
Matched one potential card from branch name [
  '34-xxxxxxxx',
  '34',
  'xxxxxxxx',
  index: 5,
  input: 'xxxxxxxx',
  groups: undefined
]
Error: TypeError: Cannot read properties of undefined (reading 'some')
/home/runner/work/_actions/rematocorp/trello-integration-action/v9.6.2/dist/index.js:34495
        card.actions.some((action) => action.data.card.idShort === parseInt(shortId)))?.shortLink;
```

I'm not sure if this is the solution but i will appreciate feedback! 
